### PR TITLE
fix footer sticky

### DIFF
--- a/src/lib/Globals/footer.svelte
+++ b/src/lib/Globals/footer.svelte
@@ -27,11 +27,6 @@
     justify-content: space-evenly;
     padding-top: 0.6rem;
     background-color: var(--primary-color);
-
-    @media (min-width: 1080px) {
-      position: sticky;
-      bottom: 0;
-    }
   }
 
   footer ul {


### PR DESCRIPTION
🐛 bug: fixed the footer by removing position sticky

## What does this change?
 
 
The footer had a sticky position but its now removed 
 
 
## How Has This Been Tested?
 
- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [ ] Browser test
 
## Images
 
<img width="1647" height="690" alt="image" src="https://github.com/user-attachments/assets/bcb0f571-6d95-45d0-b6d1-b0a4f0d435ef" />
 
 
## How to review
 
- was it the right choice to remove this code?
