### PR TITLE
partnerships of the homepage + logo carrousel

### DIFF
--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -3,7 +3,10 @@ export async function load({ url }) {
 
         const homepageAbout = await fetch('https://fdnd-agency.directus.app/items/avl_content/3');
         const homepageWebinars = await fetch('https://fdnd-agency.directus.app/items/avl_content/6');
-        const homepageContourings = await fetch('https://fdnd-agency.directus.app/items/avl_content/7')
+        const homepageContourings = await fetch('https://fdnd-agency.directus.app/items/avl_content/7');
+        const homepagePartnerships = await fetch('https://fdnd-agency.directus.app/items/avl_content/5');
+        const homepageLogos = await fetch('https://fdnd-agency.directus.app/items/avl_logos');
+
 
         if (!homepageAbout.ok) {
             throw new Error(`HTTP error! status: ${homepageAbout.status}`);
@@ -16,15 +19,27 @@ export async function load({ url }) {
         if (!homepageContourings.ok) {
             throw new Error(`HTTP error! status: ${homepageContourings.status}`);
         }
+
+        if (!homepagePartnerships.ok) {
+            throw new Error(`HTTP error! status: ${homepagePartnerships.status}`);
+        }
+
+        if (!homepageLogos.ok) {
+            throw new Error(`HTTP error! status: ${homepageLogos.status}`)
+        }
         
         const homepageAboutData = await homepageAbout.json();
         const homepageWebinarsData = await homepageWebinars.json();
         const homepageContouringsData = await homepageContourings.json();
+        const homepagePartnershipsData = await homepagePartnerships.json();
+        const homepageLogosData = await homepageLogos.json();
 
         return {
             about: homepageAboutData.data,
             webinars: homepageWebinarsData.data,
             contourings: homepageContouringsData.data,
+            partnerships: homepagePartnershipsData.data,
+            logos: homepageLogosData.data,
             error: null
         };
     } catch (error) {
@@ -32,6 +47,8 @@ export async function load({ url }) {
             about: null,
             webinars: null,
             contourings: null,
+            partnerships: null,
+            logos: null,
             error: error.message || "Sorry, error with loading the data. Please try again."
         };
     }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -45,6 +45,7 @@
 </svelte:head>
 
 
+<main class="overlay">
 <article class="homepage-about home-mobile-styling">
     <h1 class="header-about">{infoabout.heading}</h1>
     <p class="info-about">{infoabout.text}</p>
@@ -93,9 +94,15 @@
             {/each}
         </div>
     </div>
-
+</main>
 
 <style>
+
+    .overlay {
+        display: flex;
+        align-items: center;
+        flex-direction: column;
+    }
 
     h1, h2 {
         font-size: var(--font-size-extra-large);
@@ -106,10 +113,6 @@
     }
 
     .home-mobile-styling {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        flex-direction: column;
         padding-inline: 1em;
     }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -251,6 +251,7 @@
     .homepage-partnerships {
 
         @media ( min-width: 56.25em ) {
+            width: 100%;
             align-items: start;
             padding-inline: 2rem;
         }
@@ -258,8 +259,6 @@
         @media ( min-width: 75em ) {
             position: relative;
             width: 78.125rem;
-            left: 50%;
-            transform: translateX(-50%);
         }
     }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,34 @@
 <script>
+
+    import { onMount } from 'svelte';
+
     /** @type {{ data: import('./$types').PageData }} */
     let { data } = $props();
 
     const infoabout = data.about;
     const infowebinars = data.webinars;
     const infocontourings = data.contourings;
+    const infopartnerships = data.partnerships;
+    const infologos = data.logos;
+
+
+    onMount(() => {
+    const slide = document.querySelector('.logos-slide');
+    if (!slide) return;
+
+    const totalWidth = slide.scrollWidth / 2; // Half because logos are duplicated
+    let x = 0;
+    const speed = 0.5;
+
+    function step() {
+      x -= speed;
+      if (Math.abs(x) >= totalWidth) x = 0;
+      slide.style.transform = `translateX(${x}px)`;
+      requestAnimationFrame(step);
+    }
+
+    setTimeout(() => requestAnimationFrame(step), 500);
+  });
 </script>
 
 <svelte:head> 
@@ -14,6 +38,7 @@
             margin: 0;
             padding: 0;
             box-sizing: border-box;
+            overflow-x: hidden;
         }
         
     </style>
@@ -53,6 +78,22 @@
     </article>
 </section>
 
+<article class="homepage-partnerships home-mobile-styling">
+    <h2 class="header-partnerships">{infopartnerships.heading}</h2>
+    <p class="info-partnerships">{infopartnerships.text}</p>
+</article>
+
+    <div class="logo-carrousel">
+        <div class="logos-slide">
+            {#each infologos as logo}
+               <img class="logos-partnerships" src={`https://fdnd-agency.directus.app/assets/${logo.logo}`} alt={logo.name}>
+            {/each}
+            {#each infologos as logo}
+                <img class="logos-partnerships" src={`https://fdnd-agency.directus.app/assets/${logo.logo}`} alt={logo.name}>
+            {/each}
+        </div>
+    </div>
+
 
 <style>
 
@@ -66,8 +107,8 @@
 
     .home-mobile-styling {
         display: flex;
-        align-items: center;
         justify-content: center;
+        align-items: center;
         flex-direction: column;
         padding-inline: 1em;
     }
@@ -109,7 +150,7 @@
         margin-top: 1em;
         padding-right: 1rem;
 
-        @media ( min-width: 56.25em) {
+        @media ( min-width: 56.25em ) {
             grid-column: 1/2;
             max-width: 30rem;
             margin-top: 0;
@@ -196,12 +237,75 @@
         }
     }
 
-    .header-webinars-contourings, .info-webinars-contourings, .link-webinars-contourings {
+    .header-webinars-contourings, .info-webinars-contourings, .link-webinars-contourings, .header-partnerships {
         margin-top: 2rem;
     }
 
     .info-webinars-contourings {
         padding-right: 1rem;
+    }
+
+    .homepage-partnerships {
+
+        @media ( min-width: 56.25em ) {
+            padding-inline: 2rem;
+            align-items: start;
+        }
+
+        @media ( min-width: 75em ) {
+            justify-self: center;
+            width: 78.125rem;
+        }
+
+        @media ( min-width: 80em ) {
+            margin-left: 2rem;
+        }
+    }
+
+    .header-partnerships {
+
+        @media ( min-width: 75em ) {
+            width: 48rem;
+            text-align: start;        
+        }
+    }
+
+
+    .info-partnerships {
+        margin-top: 2rem;
+        max-width: 37.5rem;
+        padding-right: 1rem;
+
+        @media ( min-width: 56.25em ) {
+            max-width: 48rem;
+        }
+    }
+
+    .logo-carrousel {
+        background-color: var(--primary-color-blue-light-1);
+        overflow: hidden;
+        margin-top: 2rem;
+        padding-block: 2rem;
+    }
+
+    .logos-slide {
+        display: flex;
+        width: max-content; 
+        gap: 5rem;
+    }
+
+    .logos-partnerships {
+        height: 15vw;
+        object-fit: contain;
+        flex-shrink: 0; 
+
+        @media ( min-width: 37.5em ) {
+            height: 10vw;
+        }
+
+        @media ( min-width: 56.25em ) {
+            height: 5vw;
+        }
     }
 
 </style>    

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -293,17 +293,8 @@
     }
 
     .logos-partnerships {
-        height: 15vw;
         object-fit: contain;
         flex-shrink: 0; 
-
-        @media ( min-width: 37.5em ) {
-            height: 10vw;
-        }
-
-        @media ( min-width: 56.25em ) {
-            height: 5vw;
-        }
     }
 
 </style>    

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -248,17 +248,15 @@
     .homepage-partnerships {
 
         @media ( min-width: 56.25em ) {
-            padding-inline: 2rem;
             align-items: start;
+            padding-inline: 2rem;
         }
 
         @media ( min-width: 75em ) {
-            justify-self: center;
+            position: relative;
             width: 78.125rem;
-        }
-
-        @media ( min-width: 80em ) {
-            margin-left: 2rem;
+            left: 50%;
+            transform: translateX(-50%);
         }
     }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -87,10 +87,18 @@
     <div class="logo-carrousel">
         <div class="logos-slide">
             {#each infologos as logo}
-               <img class="logos-partnerships" src={`https://fdnd-agency.directus.app/assets/${logo.logo}`} alt={logo.name}>
+            <picture class="logos-partnerships">
+                <source srcSet={`https://fdnd-agency.directus.app/assets/${logo.logo}?format=avif`} type="image/avif"/>
+                <source srcSet={`https://fdnd-agency.directus.app/assets/${logo.logo}?format=webp`} type="image/webp"/>
+                <img src={`https://fdnd-agency.directus.app/assets/${logo.logo}`} alt={logo.name} loading="lazy"/>
+            </picture>
             {/each}
             {#each infologos as logo}
-                <img class="logos-partnerships" src={`https://fdnd-agency.directus.app/assets/${logo.logo}`} alt={logo.name}>
+            <picture class="logos-partnerships">
+                <source srcSet={`https://fdnd-agency.directus.app/assets/${logo.logo}?format=avif`} type="image/avif"/>
+                <source srcSet={`https://fdnd-agency.directus.app/assets/${logo.logo}?format=webp`} type="image/webp"/>
+                <img src={`https://fdnd-agency.directus.app/assets/${logo.logo}`} alt={logo.name} loading="lazy"/>
+            </picture>
             {/each}
         </div>
     </div>
@@ -295,6 +303,8 @@
     }
 
     .logos-partnerships {
+        display: flex;
+        align-items: center;
         object-fit: contain;
         flex-shrink: 0; 
     }


### PR DESCRIPTION
Hierbij de partnerships en logo carrousel. voor nu is het logo carrousel niet PE enhanced en gemaakt volledig met javascript zodat het op elke browser werkt. Dit gaat nog PE worden zodat er een fallback komt voor mensen die geen javascript aan hebben staan.

Ik heb een browser test + responsive test gedaan. Waaronder de volgende browsers.

- Chrome
- Firefox
- Safari

Zodra javascript uitstaat heb ik voor nu nog geen nette fallback, het enige verschil is dat het geen automatische carrousel is.

@nadiachaja @Sidopjescherm Ik weet even geen idee hoe ik de achtergrond moet fixen voor de logo carrousel aangezien het allemaal verschillende kleuren heeft en het aanpassen van huisstijlen van andere bedrijven niet toegestaan is.

<img width="1507" height="982" alt="Screenshot 2025-10-20 at 18 55 22" src="https://github.com/user-attachments/assets/44577bcb-17b6-4cb6-bca8-f471ab449080" />
