### PR TITLE
Logo carrousel new color variant

### DIFF
--- a/src/lib/atoms/homepage-logo.svelte
+++ b/src/lib/atoms/homepage-logo.svelte
@@ -32,24 +32,16 @@
         padding: 2rem;
     }
 
-    .logos-partnerships:is(:nth-of-type(4), :nth-of-type(10)) {
-        padding-left: 0;
-    }
-
-    .logos-partnerships:is(:nth-of-type(6), :nth-of-type(12)) {
-        padding-right: 0;
-    }
-
     /* gradient overgangen op logos */
 
     .logos-partnerships:is(:nth-of-type(1), :nth-of-type(7)) {
         background: linear-gradient(to right, var(--primary-color-blue-dark-2) 0%, var(--primary-color-blue-dark-2) 10%, var(--primary-color-blue-light-1) 37%, var(--primary-color-blue-light-1) 100%);
-        padding-left: 15rem;
+        padding-left: 17rem;
     }
 
     .logos-partnerships:is(:nth-of-type(3), :nth-of-type(9)) {
         background: linear-gradient(to right, var(--primary-color-blue-light-1) 0%, var(--primary-color-blue-light-1) 50%, var(--primary-color-blue-dark-2) 90%, var(--primary-color-blue-dark-2) 100%);
-        padding-right: 15rem;
+        padding-right: 17rem;
     }
     
     /* statische kleuren op logos */

--- a/src/lib/atoms/homepage-logo.svelte
+++ b/src/lib/atoms/homepage-logo.svelte
@@ -29,32 +29,29 @@
         align-items: center;
         object-fit: contain;
         flex-shrink: 0; 
-        padding: 1rem;
+        padding: 2rem;
     }
 
-    .logos-partnerships:nth-of-type(1) {
-        background: linear-gradient(to right, var(--primary-color-blue-dark-2) 0%, var(--primary-color-blue-dark-2) 10%, var(--primary-color-blue-light-1) 40%,  var(--primary-color-blue-light-1) 100%);
+    /* gradient overgangen op logos */
+
+    .logos-partnerships:is(:nth-of-type(1), :nth-of-type(7)) {
+        background: linear-gradient(to right, var(--primary-color-blue-dark-2) 0%, var(--primary-color-blue-dark-2) 10%, var(--primary-color-blue-light-1) 37%, var(--primary-color-blue-light-1) 100%);
         padding-left: 10rem;
-
-    }
-
-    .logos-partnerships:is(:nth-of-type(2), :nth-of-type(7), :nth-of-type(8) ) {
-        background: var(--primary-color-blue-light-1);
     }
 
     .logos-partnerships:is(:nth-of-type(3), :nth-of-type(9)) {
-        background: linear-gradient(to right, var(--primary-color-blue-light-1) 0%, var(--primary-color-blue-light-1) 65%, var(--primary-color-blue-dark-2) 100%);
-        padding-right: 5rem;
+        background: linear-gradient(to right, var(--primary-color-blue-light-1) 0%, var(--primary-color-blue-light-1) 50%, var(--primary-color-blue-dark-2) 90%, var(--primary-color-blue-dark-2) 100%);
+        padding-right: 10rem;
+    }
+    
+    /* statische kleuren op logos */
+
+    .logos-partnerships:is(:nth-of-type(2), :nth-of-type(8)) {
+        background: var(--primary-color-blue-light-1);
     }
 
-    .logos-partnerships:is(:nth-of-type(4), :nth-of-type(5), :nth-of-type(6),  :nth-of-type(10)) {
+    .logos-partnerships:is(:nth-of-type(4), :nth-of-type(5), :nth-of-type(6), :nth-of-type(10)) {
         background: var(--primary-color-blue-dark-2);
-    }
-
-    .logos-partnerships:nth-of-type(7) {
-        background: linear-gradient(to right, var(--primary-color-blue-dark-2) 0%, var(--primary-color-blue-dark-2) 10%, var(--primary-color-blue-light-1) 40%,  var(--primary-color-blue-light-1) 100%);
-        padding-left: 10rem;
-
     }
     
     

--- a/src/lib/atoms/homepage-logo.svelte
+++ b/src/lib/atoms/homepage-logo.svelte
@@ -19,7 +19,8 @@
     <picture class="logos-partnerships">
         <source srcSet={`https://fdnd-agency.directus.app/assets/${logo.logo}?format=avif`} type="image/avif"/>
         <source srcSet={`https://fdnd-agency.directus.app/assets/${logo.logo}?format=webp`} type="image/webp"/>
-        <img src={`https://fdnd-agency.directus.app/assets/${logo.logo}`} alt={logo.name} loading="lazy"/>
+        <img src={`https://fdnd-agency.directus.app/assets/${logo.logo}`} alt="Logos van de partners" loading="lazy"/>
+        <!-- <img src={`https://fdnd-agency.directus.app/assets/${logo.logo}`} alt={logo.name} loading="lazy"/> -->
     </picture>
 {/each}
 

--- a/src/lib/atoms/homepage-logo.svelte
+++ b/src/lib/atoms/homepage-logo.svelte
@@ -29,6 +29,27 @@
         align-items: center;
         object-fit: contain;
         flex-shrink: 0; 
-        margin-left: 2rem;
+        padding: 1rem;
     }
+
+    .logos-partnerships:is(:nth-of-type(1), :nth-of-type(2), :nth-of-type(7), :nth-of-type(8) ) {
+        background: var(--primary-color-blue-light-1);
+    }
+
+    .logos-partnerships:is(:nth-of-type(3), :nth-of-type(9)) {
+        background: linear-gradient(to right, var(--primary-color-blue-light-1) 0%, var(--primary-color-blue-light-1) 50%, var(--primary-color-blue-dark-2) 100%);
+        padding-right: 10rem;
+    }
+
+    .logos-partnerships:is(:nth-of-type(4), :nth-of-type(5), :nth-of-type(6), :nth-of-type(10)) {
+        background: var(--primary-color-blue-dark-2);
+    }
+
+    .logos-partnerships:nth-of-type(6) {
+        background: linear-gradient(to right, var(--primary-color-blue-dark-2) 0%, var(--primary-color-blue-dark-2) 60%, var(--primary-color-blue-light-1) 100%);
+        padding-right: 10rem;
+    }
+    
+
+
 </style>

--- a/src/lib/atoms/homepage-logo.svelte
+++ b/src/lib/atoms/homepage-logo.svelte
@@ -32,23 +32,31 @@
         padding: 1rem;
     }
 
-    .logos-partnerships:is(:nth-of-type(1), :nth-of-type(2), :nth-of-type(7), :nth-of-type(8) ) {
+    .logos-partnerships:nth-of-type(1) {
+        background: linear-gradient(to right, var(--primary-color-blue-dark-2) 0%, var(--primary-color-blue-dark-2) 10%, var(--primary-color-blue-light-1) 40%,  var(--primary-color-blue-light-1) 100%);
+        padding-left: 10rem;
+
+    }
+
+    .logos-partnerships:is(:nth-of-type(2), :nth-of-type(7), :nth-of-type(8) ) {
         background: var(--primary-color-blue-light-1);
     }
 
     .logos-partnerships:is(:nth-of-type(3), :nth-of-type(9)) {
-        background: linear-gradient(to right, var(--primary-color-blue-light-1) 0%, var(--primary-color-blue-light-1) 50%, var(--primary-color-blue-dark-2) 100%);
-        padding-right: 10rem;
+        background: linear-gradient(to right, var(--primary-color-blue-light-1) 0%, var(--primary-color-blue-light-1) 65%, var(--primary-color-blue-dark-2) 100%);
+        padding-right: 5rem;
     }
 
-    .logos-partnerships:is(:nth-of-type(4), :nth-of-type(5), :nth-of-type(6), :nth-of-type(10)) {
+    .logos-partnerships:is(:nth-of-type(4), :nth-of-type(5), :nth-of-type(6),  :nth-of-type(10)) {
         background: var(--primary-color-blue-dark-2);
     }
 
-    .logos-partnerships:nth-of-type(6) {
-        background: linear-gradient(to right, var(--primary-color-blue-dark-2) 0%, var(--primary-color-blue-dark-2) 60%, var(--primary-color-blue-light-1) 100%);
-        padding-right: 10rem;
+    .logos-partnerships:nth-of-type(7) {
+        background: linear-gradient(to right, var(--primary-color-blue-dark-2) 0%, var(--primary-color-blue-dark-2) 10%, var(--primary-color-blue-light-1) 40%,  var(--primary-color-blue-light-1) 100%);
+        padding-left: 10rem;
+
     }
+    
     
 
 

--- a/src/lib/atoms/homepage-logo.svelte
+++ b/src/lib/atoms/homepage-logo.svelte
@@ -32,6 +32,14 @@
         padding: 2rem;
     }
 
+    .logos-partnerships:is(:nth-of-type(4), :nth-of-type(10)) {
+        padding-left: 0;
+    }
+
+    .logos-partnerships:is(:nth-of-type(6), :nth-of-type(12)) {
+        padding-right: 0;
+    }
+
     /* gradient overgangen op logos */
 
     .logos-partnerships:is(:nth-of-type(1), :nth-of-type(7)) {

--- a/src/lib/atoms/homepage-logo.svelte
+++ b/src/lib/atoms/homepage-logo.svelte
@@ -44,12 +44,12 @@
 
     .logos-partnerships:is(:nth-of-type(1), :nth-of-type(7)) {
         background: linear-gradient(to right, var(--primary-color-blue-dark-2) 0%, var(--primary-color-blue-dark-2) 10%, var(--primary-color-blue-light-1) 37%, var(--primary-color-blue-light-1) 100%);
-        padding-left: 10rem;
+        padding-left: 15rem;
     }
 
     .logos-partnerships:is(:nth-of-type(3), :nth-of-type(9)) {
         background: linear-gradient(to right, var(--primary-color-blue-light-1) 0%, var(--primary-color-blue-light-1) 50%, var(--primary-color-blue-dark-2) 90%, var(--primary-color-blue-dark-2) 100%);
-        padding-right: 10rem;
+        padding-right: 15rem;
     }
     
     /* statische kleuren op logos */

--- a/src/lib/molecules/carrousel.svelte
+++ b/src/lib/molecules/carrousel.svelte
@@ -37,12 +37,10 @@
         display: flex;
         overflow-x: auto;
         scroll-behavior: smooth;
-        /* background: linear-gradient(to right, var(--primary-color-blue-light-1), var(--primary-color-blue-dark-2));
-        padding-block: 1rem; */
 
-        @supports (animation: scroll 18s linear infinite) {
+        @supports (animation: scroll 10s linear infinite) {
             width: max-content;
-            animation: scroll 18s linear infinite;
+            animation: scroll 10s linear infinite;
         }
 
         @media (prefers-reduced-motion: reduce) {

--- a/src/lib/molecules/carrousel.svelte
+++ b/src/lib/molecules/carrousel.svelte
@@ -37,6 +37,8 @@
         display: flex;
         overflow-x: auto;
         scroll-behavior: smooth;
+        /* background: linear-gradient(to right, var(--primary-color-blue-light-1), var(--primary-color-blue-dark-2));
+        padding-block: 1rem; */
 
         @supports (animation: scroll 18s linear infinite) {
             width: max-content;

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -46,7 +46,7 @@ export async function load({ url }) {
         const homepageDoctorInfoData = await homepageDoctorInfo.json();
         const homepageDoctorsData = await homepageDoctors.json();
 
-        // i use mapping under here because i know that the logos id are all correct
+        // gebruik van mapping voor het ordenen van de logo's dit is deels gemaakt met hulp van ai
 
         const logosOrder = [5, 1, 2, 4, 3, 6];
 
@@ -59,7 +59,7 @@ export async function load({ url }) {
             webinars: homepageWebinarsData.data,
             contourings: homepageContouringsData.data,
             partnerships: homepagePartnershipsData.data,
-            logos: logosSorted, // Aangepast: we geven nu de gesorteerde lijst door!
+            logos: logosSorted, 
             doctorinfo: homepageDoctorInfoData.data,
             doctors: homepageDoctorsData.data,
             error: null

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -46,18 +46,27 @@ export async function load({ url }) {
         const homepageDoctorInfoData = await homepageDoctorInfo.json();
         const homepageDoctorsData = await homepageDoctors.json();
 
+        // i use mapping under here because i know that the logos id are all correct
+
+        const logosOrder = [5, 1, 2, 4, 3, 6];
+
+        const logosSorted = logosOrder.map(id => 
+            homepageLogosData.data.find(logo => logo.id === id)
+        );
 
         return {
             about: homepageAboutData.data,
             webinars: homepageWebinarsData.data,
             contourings: homepageContouringsData.data,
             partnerships: homepagePartnershipsData.data,
-            logos: homepageLogosData.data,
+            logos: logosSorted, // Aangepast: we geven nu de gesorteerde lijst door!
             doctorinfo: homepageDoctorInfoData.data,
             doctors: homepageDoctorsData.data,
             error: null
         };
-    } catch (error) {
+    } 
+    
+    catch (error) {
         return {
             about: null,
             webinars: null,


### PR DESCRIPTION
Hierbij het logo carousel met een bijpassende achtergrond kleur in de stijl van Oncollaboration. Ik heb bij witte logos donkerblauw gekozen en bij de donkere logos een lichtblauwe achtergrond. Ik vond hoe het nu is persoonlijk de beste oplossing, ik heb het nog iets mooier gemaakt door een gap van 10rem tussen licht en donker te doen zodat de gradient vloeiend kan overlopen.

### Ik heb getest op:

- Mobile
- Ipad
- Desktop
- Chrome
- Safari
- Firefox
- kleuren

**Mobile Responsive**

<img width="349" height="763" alt="Screenshot 2026-01-23 at 14 18 28" src="https://github.com/user-attachments/assets/097cc6eb-c283-4418-aedd-6f4378aecd58" />

**Tablet Responsive**

<img width="534" height="763" alt="Screenshot 2026-01-23 at 14 19 28" src="https://github.com/user-attachments/assets/769b9e3b-c712-4df6-9e8d-72fc589f25af" />

**Desktop responsive**

<img width="1495" height="859" alt="Screenshot 2026-01-23 at 14 20 04" src="https://github.com/user-attachments/assets/43121123-b7c5-4361-b441-74622a749612" />



**Chrome**

https://github.com/user-attachments/assets/262ca175-be31-43da-a1f2-85772497f89a

**Internet Explorer**

https://github.com/user-attachments/assets/23cd4c9a-d093-4c64-b55e-9a5e7d11e7a9

**Safari**

https://github.com/user-attachments/assets/6cf05767-098c-4f0d-9771-c2a487ba9439

**Kleuren**

zoals te zien zelfs bij meerdere types kleurenblind is het carrousel en de algemene pagina nog goed toegankelijk!

<img width="1495" height="859" alt="Screenshot 2026-01-24 at 13 20 06" src="https://github.com/user-attachments/assets/7cd921b5-e98f-4d76-b532-67bce75c87e9" />

<img width="1495" height="859" alt="Screenshot 2026-01-24 at 13 20 49" src="https://github.com/user-attachments/assets/e978991b-d184-4897-b153-448695a55782" />

<img width="1495" height="859" alt="Screenshot 2026-01-24 at 13 21 15" src="https://github.com/user-attachments/assets/5342f2bd-b6f0-494a-8efc-9ceb0606c5d3" />







Mochten jullie nog feedback hebben hoor ik het graag.


<img width="1175" height="161" alt="Screenshot 2026-01-11 at 15 54 55" src="https://github.com/user-attachments/assets/91225f7f-87ca-4acf-9968-edabfcf7f16b" />
